### PR TITLE
Refactor imports, introduce preludes

### DIFF
--- a/src/client/collider/components.rs
+++ b/src/client/collider/components.rs
@@ -1,7 +1,6 @@
-use bevy::ecs::component::Component;
+use crate::prelude::*;
 
 #[derive(Component)]
 pub struct MyCollider {
     pub key: u32,
 }
-

--- a/src/client/collider/events.rs
+++ b/src/client/collider/events.rs
@@ -1,4 +1,4 @@
-use bevy::ecs::event::Event;
+use crate::prelude::*;
 
 #[derive(Event)]
 pub struct ColliderUpdateEvent {

--- a/src/client/collider/mod.rs
+++ b/src/client/collider/mod.rs
@@ -2,14 +2,17 @@ pub mod components;
 pub mod events;
 pub mod systems;
 
-use bevy::app::{App, Plugin, Startup, Update};
-use systems::*;
+use crate::prelude::*;
 
 pub struct ColliderPlugin;
 
 impl Plugin for ColliderPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, setup_coliders_system);
-        app.add_systems(Update, handle_collider_update_events_system);
+        app.add_systems(Startup, collider_systems::setup_coliders_system);
+        app.add_event::<collider_events::ColliderUpdateEvent>();
+        app.add_systems(
+            Update,
+            collider_systems::handle_collider_update_events_system,
+        );
     }
 }

--- a/src/client/collider/systems.rs
+++ b/src/client/collider/systems.rs
@@ -1,15 +1,4 @@
-use bevy::ecs::event::EventReader;
-use bevy::transform::components::*;
-use bevy::math::*;
-use bevy::ecs::system::*;
-use bevy::transform::*;
-use bevy_rapier3d::geometry::*;
-
-use crate::terrain::resources::ChunkManager;
-use crate::terrain::util::blocks::BlockId;
-
-use super::components::MyCollider;
-use super::events::ColliderUpdateEvent;
+use crate::prelude::*;
 
 static COLLIDER_GRID_SIZE: u32 = 3;
 static COLLIDER_RESTING_POSITION: Vec3 = Vec3::new(0.0, 0.0, 0.0);
@@ -26,16 +15,16 @@ pub fn setup_coliders_system(mut commands: Commands) {
                     .insert(TransformBundle::from(Transform::from_xyz(
                         x as f32, y as f32, z as f32,
                     )))
-                    .insert(MyCollider { key });
+                    .insert(collider_components::MyCollider { key });
             }
         }
     }
 }
 
 pub fn handle_collider_update_events_system(
-    mut collider_grid_events: EventReader<ColliderUpdateEvent>,
-    mut query: Query<(&mut Transform, &MyCollider)>,
-    mut chunk_manager: ResMut<ChunkManager>,
+    mut collider_grid_events: EventReader<collider_events::ColliderUpdateEvent>,
+    mut query: Query<(&mut Transform, &collider_components::MyCollider)>,
+    mut chunk_manager: ResMut<terrain_resources::ChunkManager>,
 ) {
     for event in collider_grid_events.read() {
         let event_position =

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -1,9 +1,10 @@
 use crate::prelude::*;
 
+pub mod prelude;
+
 mod collider;
 mod networking;
 mod player;
-pub mod prelude;
 mod scene;
 mod terrain;
 use scene::setup_scene;

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -1,14 +1,12 @@
-use bevy::diagnostic::*;
-use bevy::prelude::*;
-use bevy::window::*;
-use iyes_perf_ui::prelude::*;
-use scene::setup_scene;
+use crate::prelude::*;
 
 mod collider;
 mod networking;
 mod player;
+pub mod prelude;
 mod scene;
 mod terrain;
+use scene::setup_scene;
 
 fn main() {
     let window_plugin = WindowPlugin {

--- a/src/client/networking/mod.rs
+++ b/src/client/networking/mod.rs
@@ -1,16 +1,6 @@
-use std::{
-    net::{UdpSocket},
-    time::SystemTime,
-};
+pub mod systems;
 
-use bevy::{app::{App, Plugin, Update}};
-use bevy_renet::{transport::NetcodeClientPlugin, RenetClientPlugin};
-use renet::{
-    transport::{ClientAuthentication, NetcodeClientTransport},
-    ConnectionConfig, RenetClient,
-};
-
-mod systems;
+use crate::prelude::*;
 
 const SERVER_ADDR: &str = "127.0.0.1:5000";
 

--- a/src/client/networking/systems.rs
+++ b/src/client/networking/systems.rs
@@ -1,5 +1,6 @@
-use bevy::ecs::system::ResMut;
-use renet::{DefaultChannel, RenetClient};
+use renet::DefaultChannel;
+
+use crate::prelude::*;
 
 pub fn receive_message_system(
     mut client: ResMut<RenetClient>,

--- a/src/client/player/components.rs
+++ b/src/client/player/components.rs
@@ -1,4 +1,4 @@
-use bevy::ecs::component::Component;
+use crate::prelude::*;
 
 #[derive(Component)]
 pub struct HighlightCube;

--- a/src/client/player/mod.rs
+++ b/src/client/player/mod.rs
@@ -1,21 +1,8 @@
-use bevy::app::*;
-use bevy::math::*;
-use bevy_fps_controller::controller::FpsControllerPlugin;
-use bevy_rapier3d::{
-    plugin::{NoUserData, RapierConfiguration, RapierPhysicsPlugin, TimestepMode},
-    render::RapierDebugRenderPlugin,
-};
+pub mod components;
+pub mod resources;
+pub mod systems;
 
-mod components;
-mod resources;
-mod systems;
-
-use resources::*;
-use systems::*;
-
-use crate::collider::events::ColliderUpdateEvent;
-
-use self::world::handle_block_update_events;
+use crate::prelude::*;
 
 pub struct PlayerPlugin;
 
@@ -35,22 +22,24 @@ impl Plugin for PlayerPlugin {
                 substeps: 1,
             },
         });
-        app.insert_resource(BlockSelection::new());
-        app.insert_resource(LastPlayerPosition::new());
-        app.add_event::<ColliderUpdateEvent>();
+        app.insert_resource(player_resources::BlockSelection::new());
+        app.insert_resource(player_resources::LastPlayerPosition::new());
         app.add_systems(
             Startup,
-            (setup_controller_system, setup_highlight_cube_system),
+            (
+                player_systems::setup_controller_system,
+                player_systems::setup_highlight_cube_system,
+            ),
         );
         app.add_systems(
             Update,
             (
-                handle_controller_movement_system,
-                manage_cursor_system,
-                handle_mouse_events_system,
-                handle_keyboard_events_system,
-                raycast_system,
-                handle_block_update_events,
+                player_systems::handle_controller_movement_system,
+                player_systems::manage_cursor_system,
+                player_systems::handle_mouse_events_system,
+                player_systems::handle_keyboard_events_system,
+                player_systems::raycast_system,
+                player_systems::handle_block_update_events,
             ),
         );
     }

--- a/src/client/player/resources.rs
+++ b/src/client/player/resources.rs
@@ -6,6 +6,12 @@ pub struct BlockSelection {
     pub normal: Option<Vec3>,
 }
 
+impl Default for BlockSelection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BlockSelection {
     pub fn new() -> Self {
         Self {
@@ -17,6 +23,12 @@ impl BlockSelection {
 
 #[derive(Resource)]
 pub struct LastPlayerPosition(pub Vec3);
+
+impl Default for LastPlayerPosition {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl LastPlayerPosition {
     pub fn new() -> Self {

--- a/src/client/player/resources.rs
+++ b/src/client/player/resources.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::system::Resource, math::Vec3};
+use crate::prelude::*;
 
 #[derive(Resource)]
 pub struct BlockSelection {

--- a/src/client/player/systems/controller.rs
+++ b/src/client/player/systems/controller.rs
@@ -1,11 +1,4 @@
-use std::f32::consts::TAU;
-
-use bevy::prelude::*;
-use bevy_rapier3d::prelude::*;
-
-use bevy_fps_controller::controller::*;
-
-use crate::{collider::events::ColliderUpdateEvent, player::LastPlayerPosition};
+use crate::prelude::*;
 
 const SPAWN_POINT: Vec3 = Vec3::new(0.0, 256.0, 0.0);
 
@@ -67,17 +60,16 @@ pub fn setup_controller_system(mut commands: Commands, mut window: Query<&mut Wi
 
 pub fn handle_controller_movement_system(
     query: Query<(Entity, &FpsControllerInput, &Transform)>,
-    mut last_position: ResMut<LastPlayerPosition>,
-    mut collider_events: EventWriter<ColliderUpdateEvent>,
+    mut last_position: ResMut<player_resources::LastPlayerPosition>,
+    mut collider_events: EventWriter<collider_events::ColliderUpdateEvent>,
 ) {
     for (_entity, _input, transform) in &mut query.iter() {
         let controller_position = transform.translation;
         if last_position.0.floor() != controller_position.floor() {
-            collider_events.send(ColliderUpdateEvent {
+            collider_events.send(collider_events::ColliderUpdateEvent {
                 position: controller_position.into(),
             });
         }
         last_position.0 = controller_position;
     }
 }
-

--- a/src/client/player/systems/keyboard.rs
+++ b/src/client/player/systems/keyboard.rs
@@ -1,10 +1,9 @@
-use bevy::{ecs::{event::*, query::With, system::Query}, input::keyboard::*, transform::components::Transform};
-use crate::{collider::events::ColliderUpdateEvent, player::components::HighlightCube};
+use crate::prelude::*;
 
 pub fn handle_keyboard_events_system(
     mut keyboard_events: EventReader<KeyboardInput>,
-    camera_query: Query<&Transform, With<HighlightCube>>,
-    mut collider_events: EventWriter<ColliderUpdateEvent>,
+    camera_query: Query<&Transform, With<player_components::HighlightCube>>,
+    mut collider_events: EventWriter<collider_events::ColliderUpdateEvent>,
 ) {
     for event in keyboard_events.read() {
         if event.state.is_pressed() {
@@ -13,7 +12,7 @@ pub fn handle_keyboard_events_system(
                 bevy::input::keyboard::KeyCode::KeyC => {
                     let controller_transform = camera_query.single();
                     println!("Handling event: {:?}", controller_transform.translation);
-                    collider_events.send(ColliderUpdateEvent {
+                    collider_events.send(collider_events::ColliderUpdateEvent {
                         position: controller_transform.translation.into(),
                     });
                 }
@@ -22,4 +21,3 @@ pub fn handle_keyboard_events_system(
         }
     }
 }
-

--- a/src/client/player/systems/mod.rs
+++ b/src/client/player/systems/mod.rs
@@ -8,3 +8,4 @@ pub use controller::*;
 pub use keyboard::*;
 pub use mouse::*;
 pub use selection::*;
+pub use world::*;

--- a/src/client/player/systems/mouse.rs
+++ b/src/client/player/systems/mouse.rs
@@ -1,7 +1,4 @@
-use bevy::{ecs::{event::{EventReader, EventWriter}, system::{Query, Res}}, input::{keyboard::KeyCode, mouse::{MouseButton, MouseButtonInput}, ButtonInput}, window::{CursorGrabMode, Window}};
-use bevy_fps_controller::controller::FpsController;
-
-use crate::{player::BlockSelection, terrain::{events::BlockUpdateEvent, util::blocks::BlockId}};
+use crate::prelude::*;
 
 pub fn manage_cursor_system(
     btn: Res<ButtonInput<MouseButton>>,
@@ -27,9 +24,9 @@ pub fn manage_cursor_system(
 }
 
 pub fn handle_mouse_events_system(
-    mut block_update_events: EventWriter<BlockUpdateEvent>,
+    mut block_update_events: EventWriter<terrain_events::BlockUpdateEvent>,
     mut mouse_events: EventReader<MouseButtonInput>,
-    block_selection: Res<BlockSelection>,
+    block_selection: Res<player_resources::BlockSelection>,
 ) {
     if block_selection.normal.is_none() || block_selection.position.is_none() {
         return;
@@ -40,12 +37,12 @@ pub fn handle_mouse_events_system(
 
     for event in mouse_events.read() {
         if event.button == MouseButton::Left && event.state.is_pressed() {
-            block_update_events.send(BlockUpdateEvent {
+            block_update_events.send(terrain_events::BlockUpdateEvent {
                 position,
                 block: BlockId::Air,
             });
         } else if event.button == MouseButton::Right && event.state.is_pressed() {
-            block_update_events.send(BlockUpdateEvent {
+            block_update_events.send(terrain_events::BlockUpdateEvent {
                 position: position + normal,
                 block: BlockId::Dirt,
             });

--- a/src/client/player/systems/selection.rs
+++ b/src/client/player/systems/selection.rs
@@ -1,7 +1,4 @@
-use bevy::{asset::Assets, ecs::{query::{With, Without}, system::{Commands, Query, ResMut}}, gizmos::gizmos::Gizmos, math::{primitives::Cuboid, Ray3d, Vec3}, pbr::{PbrBundle, StandardMaterial}, prelude::default, render::{camera::Camera, color::Color, mesh::Mesh}, transform::components::Transform};
-use bevy_mod_raycast::immediate::{Raycast, RaycastSettings};
-
-use crate::player::{components::HighlightCube, BlockSelection};
+use crate::prelude::*;
 
 const RAY_DIST: Vec3 = Vec3::new(0.0, 0.0, -20.0);
 
@@ -19,15 +16,18 @@ pub fn setup_highlight_cube_system(
             transform: Transform::from_xyz(0.0, 0.0, -7.0),
             ..default()
         })
-        .insert(HighlightCube);
+        .insert(player_components::HighlightCube);
 }
 
 pub fn raycast_system(
     mut raycast: Raycast,
     mut gizmos: Gizmos,
     query: Query<&Transform, With<Camera>>,
-    mut highlight_query: Query<(&mut Transform, &HighlightCube), Without<Camera>>,
-    mut block_selection: ResMut<BlockSelection>,
+    mut highlight_query: Query<
+        (&mut Transform, &player_components::HighlightCube),
+        Without<Camera>,
+    >,
+    mut block_selection: ResMut<player_resources::BlockSelection>,
 ) {
     let camera_transform = query.single();
     let filter = |entity| !highlight_query.contains(entity);
@@ -62,4 +62,3 @@ pub fn raycast_system(
 
     highlight_transform.translation = hover_position.unwrap() + 0.5;
 }
-

--- a/src/client/player/systems/world.rs
+++ b/src/client/player/systems/world.rs
@@ -1,17 +1,14 @@
-use bevy::ecs::{event::{EventReader, EventWriter}, system::ResMut};
-
-use crate::terrain::{events::{BlockUpdateEvent, ChunkMeshUpdateEvent}, resources::ChunkManager, util::chunk::CHUNK_SIZE};
+use crate::prelude::*;
 
 pub fn handle_block_update_events(
-    mut chunk_manager: ResMut<ChunkManager>,
-    mut block_update_events: EventReader<BlockUpdateEvent>,
-    mut chunk_mesh_update_events: EventWriter<ChunkMeshUpdateEvent>,
+    mut chunk_manager: ResMut<terrain_resources::ChunkManager>,
+    mut block_update_events: EventReader<terrain_events::BlockUpdateEvent>,
+    mut chunk_mesh_update_events: EventWriter<terrain_events::ChunkMeshUpdateEvent>,
 ) {
     for event in block_update_events.read() {
         chunk_manager.set_block(event.position, event.block);
-        chunk_mesh_update_events.send(ChunkMeshUpdateEvent {
+        chunk_mesh_update_events.send(terrain_events::ChunkMeshUpdateEvent {
             position: event.position / CHUNK_SIZE as f32,
         });
     }
 }
-

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -14,50 +14,41 @@ pub use crate::{
     },
 };
 
-pub use bevy::app::*;
-pub use bevy::app::{App, Plugin, Startup, Update};
-pub use bevy::diagnostic::*;
-pub use bevy::math::*;
-pub use bevy::prelude::*;
-pub use bevy::render::camera::Camera;
-pub use bevy::window::*;
 pub use bevy::{
     asset::Assets,
-    ecs::{query::Without, system::ResMut},
-    gizmos::gizmos::Gizmos,
-    math::{primitives::Cuboid, Ray3d, Vec3},
-    pbr::{PbrBundle, StandardMaterial},
-    render::{color::Color, mesh::Mesh},
-};
-pub use bevy::{
-    ecs::system::Commands,
-    math::{EulerRot, Quat},
-    pbr::{light_consts, CascadeShadowConfigBuilder, DirectionalLight, DirectionalLightBundle},
-    prelude::default,
-    transform::components::Transform,
-};
-pub use bevy::{
-    ecs::{event::*, query::With, system::Query},
-    input::keyboard::*,
-};
-pub use bevy::{
+    diagnostic::*,
     ecs::{
-        event::{EventReader, EventWriter},
-        system::Res,
+        event::*, query::With, query::Without, system::Commands, system::Query, system::Res,
+        system::ResMut,
     },
+    gizmos::gizmos::Gizmos,
     input::{
-        keyboard::KeyCode,
+        keyboard::*,
         mouse::{MouseButton, MouseButtonInput},
         ButtonInput,
     },
-    window::{CursorGrabMode, Window},
+    math::{primitives::Cuboid, EulerRot, Quat, Ray3d, Vec3},
+    pbr::{
+        light_consts, CascadeShadowConfigBuilder, DirectionalLight, DirectionalLightBundle,
+        PbrBundle, StandardMaterial,
+    },
+    prelude::*,
+    render::{camera::*, color::Color, mesh::Mesh},
+    transform::components::Transform,
+    window::{CursorGrabMode, Window, *},
 };
 pub use bevy_fps_controller::controller::FpsController;
 pub use bevy_fps_controller::controller::FpsControllerPlugin;
 pub use bevy_fps_controller::controller::*;
 pub use bevy_mod_raycast::immediate::{Raycast, RaycastSettings};
 pub use bevy_rapier3d::geometry::Collider;
-pub use bevy_rapier3d::prelude::*;
+pub use bevy_rapier3d::{
+    dynamics::{
+        AdditionalMassProperties, Ccd, CoefficientCombineRule, GravityScale, LockedAxes, RigidBody,
+        Sleeping, Velocity,
+    },
+    geometry::{ActiveEvents, Friction, Restitution},
+};
 pub use bevy_rapier3d::{
     plugin::{NoUserData, RapierConfiguration, RapierPhysicsPlugin, TimestepMode},
     render::RapierDebugRenderPlugin,

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -1,39 +1,41 @@
+// my crate
 pub use crate::terrain::util::blocks::BlockId;
 pub use crate::terrain::util::chunk::CHUNK_SIZE;
-pub use crate::{
-    collider::{
-        components as collider_components, events as collider_events, systems as collider_systems,
-    },
-    networking::systems as networking_systems,
-    player::{
-        components as player_components, resources as player_resources, systems as player_systems,
-    },
-    terrain::{
-        components as terrain_components, events as terrain_events, resources as terrain_resources,
-        systems as terrain_systems, util as terrain_util,
-    },
-};
 
+pub use crate::collider::components as collider_components;
+pub use crate::collider::events as collider_events;
+pub use crate::collider::systems as collider_systems;
+
+pub use crate::networking::systems as networking_systems;
+pub use crate::networking::NetworkingPlugin;
+
+pub use crate::player::components as player_components;
+pub use crate::player::resources as player_resources;
+pub use crate::player::systems as player_systems;
+
+pub use crate::terrain::components as terrain_components;
+pub use crate::terrain::events as terrain_events;
+pub use crate::terrain::resources as terrain_resources;
+pub use crate::terrain::systems as terrain_systems;
+pub use crate::terrain::util as terrain_util;
+
+// std crates
 pub use std::collections::HashMap;
 pub use std::f32::consts::*;
 pub use std::{net::*, time::*};
 
-pub use bevy::{
-    asset::Assets,
-    diagnostic::*,
-    ecs::{event::*, query::*, system::*},
-    gizmos::gizmos::*,
-    input::{keyboard::*, mouse::*, ButtonInput},
-    math::{primitives::Cuboid, EulerRot, Quat, Ray3d, Vec3},
-    pbr::{
-        light_consts, CascadeShadowConfigBuilder, DirectionalLight, DirectionalLightBundle,
-        PbrBundle, StandardMaterial,
-    },
-    prelude::*,
-    render::{camera::*, color::Color, mesh::Mesh},
-    transform::components::Transform,
-    window::{CursorGrabMode, Window, *},
-};
+// bevy crates
+pub use bevy::asset::Assets;
+pub use bevy::diagnostic::*;
+pub use bevy::ecs::{event::*, query::*, system::*};
+pub use bevy::gizmos::gizmos::*;
+pub use bevy::input::{keyboard::*, mouse::*, ButtonInput};
+pub use bevy::math::{primitives::Cuboid, EulerRot, Quat, Ray3d, Vec3};
+pub use bevy::pbr::*;
+pub use bevy::prelude::*;
+pub use bevy::render::{camera::*, color::Color, mesh::Mesh};
+pub use bevy::transform::components::Transform;
+pub use bevy::window::{CursorGrabMode, Window, WindowResolution};
 
 pub use bevy_fps_controller::controller::FpsController;
 pub use bevy_fps_controller::controller::FpsControllerPlugin;
@@ -45,9 +47,11 @@ pub use bevy_rapier3d::geometry::Collider;
 pub use bevy_rapier3d::{dynamics::*, geometry::*};
 pub use bevy_rapier3d::{plugin::*, render::RapierDebugRenderPlugin};
 
+// networking crates
 pub use bevy_renet::{transport::NetcodeClientPlugin, *};
 pub use renet::transport::{ClientAuthentication, NetcodeClientTransport};
 pub use renet::{ConnectionConfig, RenetClient};
 
+// other crates
 pub use iyes_perf_ui::prelude::*;
 pub use iyes_perf_ui::PerfUiCompleteBundle;

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -64,3 +64,4 @@ pub use std::collections::HashMap;
 pub use std::f32::consts::PI;
 pub use std::f32::consts::TAU;
 pub use std::{net::UdpSocket, time::SystemTime};
+pub use renet::DefaultChannel;

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -14,19 +14,16 @@ pub use crate::{
     },
 };
 
+pub use std::collections::HashMap;
+pub use std::f32::consts::*;
+pub use std::{net::*, time::*};
+
 pub use bevy::{
     asset::Assets,
     diagnostic::*,
-    ecs::{
-        event::*, query::With, query::Without, system::Commands, system::Query, system::Res,
-        system::ResMut,
-    },
-    gizmos::gizmos::Gizmos,
-    input::{
-        keyboard::*,
-        mouse::{MouseButton, MouseButtonInput},
-        ButtonInput,
-    },
+    ecs::{event::*, query::*, system::*},
+    gizmos::gizmos::*,
+    input::{keyboard::*, mouse::*, ButtonInput},
     math::{primitives::Cuboid, EulerRot, Quat, Ray3d, Vec3},
     pbr::{
         light_consts, CascadeShadowConfigBuilder, DirectionalLight, DirectionalLightBundle,
@@ -37,31 +34,20 @@ pub use bevy::{
     transform::components::Transform,
     window::{CursorGrabMode, Window, *},
 };
+
 pub use bevy_fps_controller::controller::FpsController;
 pub use bevy_fps_controller::controller::FpsControllerPlugin;
 pub use bevy_fps_controller::controller::*;
-pub use bevy_mod_raycast::immediate::{Raycast, RaycastSettings};
+
+pub use bevy_mod_raycast::immediate::*;
+
 pub use bevy_rapier3d::geometry::Collider;
-pub use bevy_rapier3d::{
-    dynamics::{
-        AdditionalMassProperties, Ccd, CoefficientCombineRule, GravityScale, LockedAxes, RigidBody,
-        Sleeping, Velocity,
-    },
-    geometry::{ActiveEvents, Friction, Restitution},
-};
-pub use bevy_rapier3d::{
-    plugin::{NoUserData, RapierConfiguration, RapierPhysicsPlugin, TimestepMode},
-    render::RapierDebugRenderPlugin,
-};
-pub use bevy_renet::{transport::NetcodeClientPlugin, RenetClientPlugin};
+pub use bevy_rapier3d::{dynamics::*, geometry::*};
+pub use bevy_rapier3d::{plugin::*, render::RapierDebugRenderPlugin};
+
+pub use bevy_renet::{transport::NetcodeClientPlugin, *};
+pub use renet::transport::{ClientAuthentication, NetcodeClientTransport};
+pub use renet::{ConnectionConfig, RenetClient};
+
 pub use iyes_perf_ui::prelude::*;
 pub use iyes_perf_ui::PerfUiCompleteBundle;
-pub use renet::{
-    transport::{ClientAuthentication, NetcodeClientTransport},
-    ConnectionConfig, RenetClient,
-};
-pub use std::collections::HashMap;
-pub use std::f32::consts::PI;
-pub use std::f32::consts::TAU;
-pub use std::{net::UdpSocket, time::SystemTime};
-pub use renet::DefaultChannel;

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -19,6 +19,7 @@ pub use bevy::app::{App, Plugin, Startup, Update};
 pub use bevy::diagnostic::*;
 pub use bevy::math::*;
 pub use bevy::prelude::*;
+pub use bevy::render::camera::Camera;
 pub use bevy::window::*;
 pub use bevy::{
     asset::Assets,
@@ -51,14 +52,12 @@ pub use bevy::{
     },
     window::{CursorGrabMode, Window},
 };
-pub use bevy::{math::*, prelude::*, render::camera::Camera};
 pub use bevy_fps_controller::controller::FpsController;
 pub use bevy_fps_controller::controller::FpsControllerPlugin;
 pub use bevy_fps_controller::controller::*;
 pub use bevy_mod_raycast::immediate::{Raycast, RaycastSettings};
 pub use bevy_rapier3d::geometry::Collider;
 pub use bevy_rapier3d::prelude::*;
-pub use bevy_rapier3d::{dynamics::*, geometry::*};
 pub use bevy_rapier3d::{
     plugin::{NoUserData, RapierConfiguration, RapierPhysicsPlugin, TimestepMode},
     render::RapierDebugRenderPlugin,

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -1,0 +1,76 @@
+pub use crate::terrain::util::blocks::BlockId;
+pub use crate::terrain::util::chunk::CHUNK_SIZE;
+pub use crate::{
+    collider::{
+        components as collider_components, events as collider_events, systems as collider_systems,
+    },
+    networking::systems as networking_systems,
+    player::{
+        components as player_components, resources as player_resources, systems as player_systems,
+    },
+    terrain::{
+        components as terrain_components, events as terrain_events, resources as terrain_resources,
+        systems as terrain_systems, util as terrain_util,
+    },
+};
+
+pub use bevy::app::*;
+pub use bevy::app::{App, Plugin, Startup, Update};
+pub use bevy::diagnostic::*;
+pub use bevy::math::*;
+pub use bevy::prelude::*;
+pub use bevy::window::*;
+pub use bevy::{
+    asset::Assets,
+    ecs::{query::Without, system::ResMut},
+    gizmos::gizmos::Gizmos,
+    math::{primitives::Cuboid, Ray3d, Vec3},
+    pbr::{PbrBundle, StandardMaterial},
+    render::{color::Color, mesh::Mesh},
+};
+pub use bevy::{
+    ecs::system::Commands,
+    math::{EulerRot, Quat},
+    pbr::{light_consts, CascadeShadowConfigBuilder, DirectionalLight, DirectionalLightBundle},
+    prelude::default,
+    transform::components::Transform,
+};
+pub use bevy::{
+    ecs::{event::*, query::With, system::Query},
+    input::keyboard::*,
+};
+pub use bevy::{
+    ecs::{
+        event::{EventReader, EventWriter},
+        system::Res,
+    },
+    input::{
+        keyboard::KeyCode,
+        mouse::{MouseButton, MouseButtonInput},
+        ButtonInput,
+    },
+    window::{CursorGrabMode, Window},
+};
+pub use bevy::{math::*, prelude::*, render::camera::Camera};
+pub use bevy_fps_controller::controller::FpsController;
+pub use bevy_fps_controller::controller::FpsControllerPlugin;
+pub use bevy_fps_controller::controller::*;
+pub use bevy_mod_raycast::immediate::{Raycast, RaycastSettings};
+pub use bevy_rapier3d::geometry::Collider;
+pub use bevy_rapier3d::prelude::*;
+pub use bevy_rapier3d::{dynamics::*, geometry::*};
+pub use bevy_rapier3d::{
+    plugin::{NoUserData, RapierConfiguration, RapierPhysicsPlugin, TimestepMode},
+    render::RapierDebugRenderPlugin,
+};
+pub use bevy_renet::{transport::NetcodeClientPlugin, RenetClientPlugin};
+pub use iyes_perf_ui::prelude::*;
+pub use iyes_perf_ui::PerfUiCompleteBundle;
+pub use renet::{
+    transport::{ClientAuthentication, NetcodeClientTransport},
+    ConnectionConfig, RenetClient,
+};
+pub use std::collections::HashMap;
+pub use std::f32::consts::PI;
+pub use std::f32::consts::TAU;
+pub use std::{net::UdpSocket, time::SystemTime};

--- a/src/client/scene.rs
+++ b/src/client/scene.rs
@@ -1,7 +1,4 @@
-use std::f32::consts::PI;
-
-use bevy::{ecs::system::Commands, math::{EulerRot, Quat}, pbr::{light_consts, CascadeShadowConfigBuilder, DirectionalLight, DirectionalLightBundle}, prelude::default, transform::components::Transform};
-use iyes_perf_ui::PerfUiCompleteBundle;
+use crate::prelude::*;
 
 pub fn setup_scene(mut commands: Commands) {
     commands.spawn(PerfUiCompleteBundle::default());

--- a/src/client/terrain/events.rs
+++ b/src/client/terrain/events.rs
@@ -1,5 +1,4 @@
-use bevy::{ecs::event::Event, math::Vec3};
-use crate::terrain::util::blocks::BlockId;
+use crate::prelude::*;
 
 #[derive(Event)]
 pub struct ChunkMeshUpdateEvent {
@@ -11,4 +10,3 @@ pub struct BlockUpdateEvent {
     pub position: Vec3,
     pub block: BlockId,
 }
-

--- a/src/client/terrain/mod.rs
+++ b/src/client/terrain/mod.rs
@@ -1,25 +1,19 @@
-use bevy::app::{App, Plugin, Startup, Update};
+use crate::prelude::*;
 
 pub mod components;
 pub mod events;
 pub mod resources;
-mod systems;
+pub mod systems;
 pub mod util;
-
-use components::*;
-use events::*;
-use resources::*;
-use systems::*;
-use util::*;
 
 pub struct TerrainPlugin;
 
 impl Plugin for TerrainPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(ChunkManager::new());
-        app.add_event::<BlockUpdateEvent>();
-        app.add_event::<ChunkMeshUpdateEvent>();
-        app.add_systems(Startup, setup_world_system);
-        app.add_systems(Update, handle_chunk_mesh_update_events);
+        app.insert_resource(terrain_resources::ChunkManager::new());
+        app.add_event::<terrain_events::BlockUpdateEvent>();
+        app.add_event::<terrain_events::ChunkMeshUpdateEvent>();
+        app.add_systems(Startup, terrain_systems::setup_world_system);
+        app.add_systems(Update, terrain_systems::handle_chunk_mesh_update_events);
     }
 }

--- a/src/client/terrain/resources.rs
+++ b/src/client/terrain/resources.rs
@@ -1,15 +1,8 @@
-use std::collections::HashMap;
-
-use bevy::{ecs::system::Resource, math::Vec3};
-
-use super::{
-    blocks::BlockId,
-    chunk::{self, Chunk, CHUNK_SIZE},
-};
+use crate::prelude::*;
 
 #[derive(Resource)]
 pub struct ChunkManager {
-    pub chunks: HashMap<[i32; 3], Chunk>,
+    pub chunks: HashMap<[i32; 3], terrain_util::Chunk>,
 }
 
 impl ChunkManager {
@@ -19,8 +12,8 @@ impl ChunkManager {
         }
     }
 
-    pub fn instantiate_chunks(position: Vec3, render_distance: i32) -> Vec<Chunk> {
-        let mut chunks: Vec<Chunk> = Vec::new();
+    pub fn instantiate_chunks(position: Vec3, render_distance: i32) -> Vec<terrain_util::Chunk> {
+        let mut chunks: Vec<terrain_util::Chunk> = Vec::new();
 
         for x in 0..render_distance {
             for y in 0..render_distance {
@@ -30,7 +23,7 @@ impl ChunkManager {
                         (y - render_distance / 2) as f32 + position.y,
                         (z - render_distance / 2) as f32 + position.z,
                     );
-                    let chunk = Chunk::new(chunk_position);
+                    let chunk = terrain_util::Chunk::new(chunk_position);
                     chunks.push(chunk);
                 }
             }
@@ -39,7 +32,7 @@ impl ChunkManager {
         chunks
     }
 
-    pub fn insert_chunks(&mut self, chunks: Vec<Chunk>) {
+    pub fn insert_chunks(&mut self, chunks: Vec<terrain_util::Chunk>) {
         for chunk in chunks {
             self.chunks
                 .insert(Self::position_to_key(chunk.position), chunk);
@@ -50,13 +43,13 @@ impl ChunkManager {
         [position.x as i32, position.y as i32, position.z as i32]
     }
 
-    pub fn set_chunk(&mut self, position: Vec3, chunk: Chunk) {
+    pub fn set_chunk(&mut self, position: Vec3, chunk: terrain_util::Chunk) {
         let Vec3 { x, y, z } = position;
 
         self.chunks.insert([x as i32, y as i32, z as i32], chunk);
     }
 
-    pub fn get_chunk(&mut self, position: Vec3) -> Option<&mut Chunk> {
+    pub fn get_chunk(&mut self, position: Vec3) -> Option<&mut terrain_util::Chunk> {
         let Vec3 { x, y, z } = position.floor();
 
         self.chunks.get_mut(&[x as i32, y as i32, z as i32])
@@ -66,9 +59,9 @@ impl ChunkManager {
         match self.chunk_from_selection(position) {
             Some(chunk) => {
                 let chunk_position = Vec3::new(
-                    chunk.position[0] * chunk::CHUNK_SIZE as f32,
-                    chunk.position[1] * chunk::CHUNK_SIZE as f32,
-                    chunk.position[2] * chunk::CHUNK_SIZE as f32,
+                    chunk.position[0] * CHUNK_SIZE as f32,
+                    chunk.position[1] * CHUNK_SIZE as f32,
+                    chunk.position[2] * CHUNK_SIZE as f32,
                 );
                 let local_position = (position - chunk_position).floor();
                 chunk.set(
@@ -88,9 +81,9 @@ impl ChunkManager {
         match self.chunk_from_selection(position) {
             Some(chunk) => {
                 let chunk_position = Vec3::new(
-                    chunk.position[0] * chunk::CHUNK_SIZE as f32,
-                    chunk.position[1] * chunk::CHUNK_SIZE as f32,
-                    chunk.position[2] * chunk::CHUNK_SIZE as f32,
+                    chunk.position[0] * CHUNK_SIZE as f32,
+                    chunk.position[1] * CHUNK_SIZE as f32,
+                    chunk.position[2] * CHUNK_SIZE as f32,
                 );
                 let local_position = (position - chunk_position).floor();
                 Some(chunk.get(
@@ -106,10 +99,7 @@ impl ChunkManager {
         }
     }
 
-    fn chunk_from_selection(
-        &mut self,
-        position: Vec3,
-    ) -> Option<&mut chunk::Chunk> {
+    fn chunk_from_selection(&mut self, position: Vec3) -> Option<&mut terrain_util::Chunk> {
         let chunk_position = position / CHUNK_SIZE as f32;
         self.get_chunk(chunk_position)
     }

--- a/src/client/terrain/resources.rs
+++ b/src/client/terrain/resources.rs
@@ -5,6 +5,12 @@ pub struct ChunkManager {
     pub chunks: HashMap<[i32; 3], terrain_util::Chunk>,
 }
 
+impl Default for ChunkManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ChunkManager {
     pub fn new() -> Self {
         Self {

--- a/src/client/terrain/util/mod.rs
+++ b/src/client/terrain/util/mod.rs
@@ -2,3 +2,8 @@ pub mod blocks;
 pub mod chunk;
 pub mod generator;
 pub mod mesher;
+
+pub use blocks::*;
+pub use chunk::*;
+pub use generator::*;
+pub use mesher::*;

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -1,12 +1,11 @@
-use bevy::{app::App, MinimalPlugins};
-use networking::NetworkingPlugin;
+pub mod prelude;
+pub mod networking;
 
-mod networking;
+use crate::prelude::*;
 
 fn main() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
-    app.add_plugins(NetworkingPlugin);
+    app.add_plugins(networking::NetworkingPlugin);
     app.run();
 }
-

--- a/src/server/networking/mod.rs
+++ b/src/server/networking/mod.rs
@@ -1,16 +1,6 @@
-use bevy::app::*;
-use std::{net::UdpSocket, time::SystemTime};
+pub mod systems;
 
-use bevy::{
-    app::{App, Update}
-};
-use bevy_renet::{transport::NetcodeServerPlugin, RenetServerPlugin};
-use renet::{
-    transport::{NetcodeServerTransport, ServerAuthentication, ServerConfig},
-    ConnectionConfig, RenetServer,
-};
-
-mod systems;
+use crate::prelude::*;
 
 const SERVER_ADDR: &str = "127.0.0.1:5000";
 
@@ -38,6 +28,6 @@ impl Plugin for NetworkingPlugin {
         let transport = NetcodeServerTransport::new(server_config, socket).unwrap();
         app.insert_resource(transport);
 
-        app.add_systems(Update, systems::receive_message_system);
+        app.add_systems(Update, networking_systems::receive_message_system);
     }
 }

--- a/src/server/networking/systems.rs
+++ b/src/server/networking/systems.rs
@@ -1,5 +1,4 @@
-use bevy::ecs::system::ResMut;
-use renet::{DefaultChannel, RenetServer};
+use crate::prelude::*;
 
 pub fn receive_message_system(
     mut server: ResMut<RenetServer>,

--- a/src/server/prelude.rs
+++ b/src/server/prelude.rs
@@ -1,0 +1,13 @@
+pub use crate::networking::systems as networking_systems;
+
+pub use bevy::app::*;
+pub use bevy::app::{App, Update};
+pub use bevy::ecs::system::ResMut;
+pub use bevy::MinimalPlugins;
+pub use bevy_renet::{transport::NetcodeServerPlugin, RenetServerPlugin};
+pub use renet::DefaultChannel;
+pub use renet::{
+    transport::{NetcodeServerTransport, ServerAuthentication, ServerConfig},
+    ConnectionConfig, RenetServer,
+};
+pub use std::{net::UdpSocket, time::SystemTime};

--- a/src/server/prelude.rs
+++ b/src/server/prelude.rs
@@ -1,13 +1,13 @@
 pub use crate::networking::systems as networking_systems;
 
-pub use bevy::app::*;
-pub use bevy::app::{App, Update};
-pub use bevy::ecs::system::ResMut;
-pub use bevy::MinimalPlugins;
-pub use bevy_renet::{transport::NetcodeServerPlugin, RenetServerPlugin};
-pub use renet::DefaultChannel;
-pub use renet::{
-    transport::{NetcodeServerTransport, ServerAuthentication, ServerConfig},
-    ConnectionConfig, RenetServer,
-};
 pub use std::{net::UdpSocket, time::SystemTime};
+
+pub use bevy::app::*;
+pub use bevy::ecs::system::*;
+pub use bevy::MinimalPlugins;
+
+pub use bevy_renet::transport::*;
+pub use bevy_renet::RenetServerPlugin;
+pub use renet::transport::*;
+pub use renet::DefaultChannel;
+pub use renet::*;


### PR DESCRIPTION
Introduced global imports in order to improve DX by not having to import every module manually.

Every custom event, component, resource and system is prefixed with its corresponding module name so it is very easy to spot custom code:

```rs
pub fn handle_controller_movement_system(
    query: Query<(Entity, &FpsControllerInput, &Transform)>,
    mut last_position: ResMut<player_resources::LastPlayerPosition>,
    mut collider_events: EventWriter<collider_events::ColliderUpdateEvent>,
) {
    for (_entity, _input, transform) in &mut query.iter() {
        let controller_position = transform.translation;
        if last_position.0.floor() != controller_position.floor() {
            collider_events.send(collider_events::ColliderUpdateEvent {
                position: controller_position.into(),
            });
        }
        last_position.0 = controller_position;
    }
}
```

In the above example, it is very clear, that LastPlayerPosition and ColliderUpdateEvent are custom, the rest is library code.

The system definitions are also very clear:

```rs
        app.add_systems(
            Update,
            (
                player_systems::handle_controller_movement_system,
                player_systems::manage_cursor_system,
                player_systems::handle_mouse_events_system,
                player_systems::handle_keyboard_events_system,
                player_systems::raycast_system,
                player_systems::handle_block_update_events,
                terrain_systems::handle_chunk_mesh_update_events
            ),
        );
```

The above catched some problems, where the player module added a terrain plugin system. Without the prefix, you would need to check every imported module manually. This is error prone.


TOO MUCH TIME WAS SPENT ON THIS PR!