### PR TITLE
Implement basic terrain updating

### DIFF
--- a/src/client/networking/systems.rs
+++ b/src/client/networking/systems.rs
@@ -44,7 +44,7 @@ pub fn receive_message_system(
                 }
                 lib::NetworkingMessage::BlockUpdate { position, block } => {
                     warn!("Client received block update message: {:?}", position);
-                    block_update_events.send(terrain_events::BlockUpdateEvent { position, block });
+                    block_update_events.send(terrain_events::BlockUpdateEvent { position, block, from_network: true});
                 }
                 _ => {
                     warn!("Received unknown message type. (ReliableUnordered)");

--- a/src/client/networking/systems.rs
+++ b/src/client/networking/systems.rs
@@ -5,6 +5,7 @@ pub fn receive_message_system(
     mut player_spawn_events: ResMut<Events<remote_player_events::RemotePlayerSpawnedEvent>>,
     mut player_despawn_events: ResMut<Events<remote_player_events::RemotePlayerDespawnedEvent>>,
     mut player_sync_events: ResMut<Events<remote_player_events::RemotePlayerSyncEvent>>,
+    mut block_update_events: ResMut<Events<terrain_events::BlockUpdateEvent>>,
 ) {
     while let Some(message) = client.receive_message(DefaultChannel::ReliableOrdered) {
         let message = bincode::deserialize(&message).unwrap();
@@ -21,7 +22,7 @@ pub fn receive_message_system(
                     .send(remote_player_events::RemotePlayerDespawnedEvent { client_id: event });
             }
             _ => {
-                warn!("Received unknown message type.");
+                warn!("Received unknown message type. (ReliableOrdered)");
             }
         }
     }
@@ -41,8 +42,12 @@ pub fn receive_message_system(
                     player_sync_events
                         .send(remote_player_events::RemotePlayerSyncEvent { players: event });
                 }
+                lib::NetworkingMessage::BlockUpdate { position, block } => {
+                    warn!("Client received block update message: {:?}", position);
+                    block_update_events.send(terrain_events::BlockUpdateEvent { position, block });
+                }
                 _ => {
-                    warn!("Received unknown message type.");
+                    warn!("Received unknown message type. (ReliableUnordered)");
                 }
             }
         }

--- a/src/client/networking/systems.rs
+++ b/src/client/networking/systems.rs
@@ -21,6 +21,14 @@ pub fn receive_message_system(
                 player_despawn_events
                     .send(remote_player_events::RemotePlayerDespawnedEvent { client_id: event });
             }
+            lib::NetworkingMessage::BlockUpdate { position, block } => {
+                debug!("Client received block update message: {:?}", position);
+                block_update_events.send(terrain_events::BlockUpdateEvent {
+                    position,
+                    block,
+                    from_network: true,
+                });
+            }
             _ => {
                 warn!("Received unknown message type. (ReliableOrdered)");
             }
@@ -41,10 +49,6 @@ pub fn receive_message_system(
                 lib::NetworkingMessage::PlayerSync(event) => {
                     player_sync_events
                         .send(remote_player_events::RemotePlayerSyncEvent { players: event });
-                }
-                lib::NetworkingMessage::BlockUpdate { position, block } => {
-                    warn!("Client received block update message: {:?}", position);
-                    block_update_events.send(terrain_events::BlockUpdateEvent { position, block, from_network: true});
                 }
                 _ => {
                     warn!("Received unknown message type. (ReliableUnordered)");

--- a/src/client/player/events.rs
+++ b/src/client/player/events.rs
@@ -1,0 +1,4 @@
+use crate::prelude::*;
+
+#[derive(Event)]
+pub struct PlayerColliderUpdateEvent;

--- a/src/client/player/mod.rs
+++ b/src/client/player/mod.rs
@@ -1,4 +1,5 @@
 pub mod components;
+pub mod events;
 pub mod resources;
 pub mod systems;
 
@@ -22,6 +23,7 @@ impl Plugin for PlayerPlugin {
                 substeps: 1,
             },
         });
+        app.add_event::<player_events::PlayerColliderUpdateEvent>();
         app.insert_resource(player_resources::BlockSelection::new());
         app.insert_resource(player_resources::LastPlayerPosition::new());
         app.add_systems(
@@ -41,6 +43,7 @@ impl Plugin for PlayerPlugin {
                 player_systems::raycast_system,
                 player_systems::handle_block_update_events,
                 player_systems::broadcast_player_attributes_system,
+                player_systems::handle_player_collider_events_system,
             ),
         );
     }

--- a/src/client/player/systems/mod.rs
+++ b/src/client/player/systems/mod.rs
@@ -1,13 +1,13 @@
 pub mod controller;
 pub mod keyboard;
 pub mod mouse;
-pub mod selection;
-pub mod world;
 pub mod network;
+pub mod selection;
+pub mod terrain;
 
 pub use controller::*;
 pub use keyboard::*;
 pub use mouse::*;
-pub use selection::*;
-pub use world::*;
 pub use network::*;
+pub use selection::*;
+pub use terrain::*;

--- a/src/client/player/systems/mouse.rs
+++ b/src/client/player/systems/mouse.rs
@@ -40,11 +40,13 @@ pub fn handle_mouse_events_system(
             block_update_events.send(terrain_events::BlockUpdateEvent {
                 position,
                 block: BlockId::Air,
+                from_network: false,
             });
         } else if event.button == MouseButton::Right && event.state.is_pressed() {
             block_update_events.send(terrain_events::BlockUpdateEvent {
                 position: position + normal,
                 block: BlockId::Dirt,
+                from_network: false,
             });
         }
     }

--- a/src/client/player/systems/terrain.rs
+++ b/src/client/player/systems/terrain.rs
@@ -11,17 +11,21 @@ pub fn handle_block_update_events(
     for event in block_update_events.read() {
         chunk_manager.set_block(event.position, event.block);
         info!("Block update message: {:?}", event.position);
-        client.send_message(
-            // TODO: Change channel to ReliableOrdered
-            DefaultChannel::ReliableUnordered,
-            bincode::serialize(&NetworkingMessage::BlockUpdate {
-                position: event.position,
-                block: event.block,
-            })
-            .unwrap(),
-        );
+
         chunk_mesh_update_events.send(terrain_events::ChunkMeshUpdateEvent {
             position: event.position / CHUNK_SIZE as f32,
         });
+
+        if !event.from_network {
+            client.send_message(
+                // TODO: Change channel to ReliableOrdered
+                DefaultChannel::ReliableUnordered,
+                bincode::serialize(&NetworkingMessage::BlockUpdate {
+                    position: event.position,
+                    block: event.block,
+                })
+                .unwrap(),
+            );
+        }
     }
 }

--- a/src/client/player/systems/terrain.rs
+++ b/src/client/player/systems/terrain.rs
@@ -18,8 +18,7 @@ pub fn handle_block_update_events(
 
         if !event.from_network {
             client.send_message(
-                // TODO: Change channel to ReliableOrdered
-                DefaultChannel::ReliableUnordered,
+                DefaultChannel::ReliableOrdered,
                 bincode::serialize(&NetworkingMessage::BlockUpdate {
                     position: event.position,
                     block: event.block,

--- a/src/client/player/systems/world.rs
+++ b/src/client/player/systems/world.rs
@@ -1,12 +1,25 @@
+use hello_bevy::NetworkingMessage;
+
 use crate::prelude::*;
 
 pub fn handle_block_update_events(
     mut chunk_manager: ResMut<terrain_resources::ChunkManager>,
     mut block_update_events: EventReader<terrain_events::BlockUpdateEvent>,
     mut chunk_mesh_update_events: EventWriter<terrain_events::ChunkMeshUpdateEvent>,
+    mut client: ResMut<RenetClient>,
 ) {
     for event in block_update_events.read() {
         chunk_manager.set_block(event.position, event.block);
+        info!("Block update message: {:?}", event.position);
+        client.send_message(
+            // TODO: Change channel to ReliableOrdered
+            DefaultChannel::ReliableUnordered,
+            bincode::serialize(&NetworkingMessage::BlockUpdate {
+                position: event.position,
+                block: event.block,
+            })
+            .unwrap(),
+        );
         chunk_mesh_update_events.send(terrain_events::ChunkMeshUpdateEvent {
             position: event.position / CHUNK_SIZE as f32,
         });

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -1,7 +1,7 @@
 // my crates
-pub use crate::terrain::util::blocks::BlockId;
 pub use crate::terrain::util::chunk::CHUNK_SIZE;
 pub use hello_bevy as lib;
+pub use hello_bevy::BlockId;
 
 pub use crate::collider::components as collider_components;
 pub use crate::collider::events as collider_events;
@@ -61,3 +61,13 @@ pub use renet::{ClientId, ConnectionConfig, DefaultChannel, RenetClient};
 pub use iyes_perf_ui::prelude::*;
 pub use iyes_perf_ui::PerfUiCompleteBundle;
 pub use serde::*;
+
+pub use self::terrain_util::Block;
+pub use self::terrain_util::Chunk;
+pub use bevy::render::{
+    mesh::{Indices, PrimitiveTopology},
+    render_asset::RenderAssetUsages,
+};
+pub use noise::NoiseFn;
+pub use noise::Perlin;
+pub use terrain_util::CubeFace;

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -2,6 +2,7 @@
 pub use crate::terrain::util::chunk::CHUNK_SIZE;
 pub use hello_bevy as lib;
 pub use hello_bevy::BlockId;
+pub use hello_bevy::NetworkingMessage;
 
 pub use crate::collider::components as collider_components;
 pub use crate::collider::events as collider_events;
@@ -11,6 +12,7 @@ pub use crate::networking::systems as networking_systems;
 pub use crate::networking::NetworkingPlugin;
 
 pub use crate::player::components as player_components;
+pub use crate::player::events as player_events;
 pub use crate::player::resources as player_resources;
 pub use crate::player::systems as player_systems;
 

--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -64,10 +64,8 @@ pub use serde::*;
 
 pub use self::terrain_util::Block;
 pub use self::terrain_util::Chunk;
-pub use bevy::render::{
-    mesh::{Indices, PrimitiveTopology},
-    render_asset::RenderAssetUsages,
-};
+pub use bevy::render::mesh::{Indices, PrimitiveTopology};
+pub use bevy::render::render_asset::RenderAssetUsages;
 pub use noise::NoiseFn;
 pub use noise::Perlin;
 pub use terrain_util::CubeFace;

--- a/src/client/terrain/events.rs
+++ b/src/client/terrain/events.rs
@@ -9,4 +9,5 @@ pub struct ChunkMeshUpdateEvent {
 pub struct BlockUpdateEvent {
     pub position: Vec3,
     pub block: BlockId,
+    pub from_network: bool,
 }

--- a/src/client/terrain/util/blocks.rs
+++ b/src/client/terrain/util/blocks.rs
@@ -1,22 +1,4 @@
-use super::mesher::CubeFace;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlockId {
-    Air,
-    Grass,
-    Dirt,
-    Stone,
-    Bedrock,
-    RedSand,
-    BrownTerracotta,
-    CyanTerracotta,
-    GrayTerracotta,
-    LightGrayTerracotta,
-    OrangeTerracotta,
-    RedTerracotta,
-    Terracotta,
-    YellowTerracotta,
-}
+use crate::prelude::*;
 
 pub struct Block {
     pub id: BlockId,

--- a/src/client/terrain/util/chunk.rs
+++ b/src/client/terrain/util/chunk.rs
@@ -1,6 +1,4 @@
-use bevy::math::Vec3;
-
-use super::blocks::BlockId;
+use crate::prelude::*;
 
 pub const CHUNK_SIZE: i32 = 32;
 pub const PADDED_CHUNK_SIZE: i32 = CHUNK_SIZE + 2;
@@ -13,11 +11,10 @@ pub struct Chunk {
     pub position: Vec3,
 }
 
-const AIR: BlockId = BlockId::Air;
 impl Chunk {
     pub fn new(position: Vec3) -> Self {
         Self {
-            data: [AIR; CHUNK_LENGTH],
+            data: [BlockId::Air; CHUNK_LENGTH],
             position,
         }
     }
@@ -39,8 +36,6 @@ impl Chunk {
     }
 
     pub fn key_eq_pos(key: [i32; 3], position: Vec3) -> bool {
-        position.x as i32 == key[0]
-            && position.y as i32 == key[1]
-            && position.z as i32 == key[2]
+        position.x as i32 == key[0] && position.y as i32 == key[1] && position.z as i32 == key[2]
     }
 }

--- a/src/client/terrain/util/generator.rs
+++ b/src/client/terrain/util/generator.rs
@@ -1,7 +1,4 @@
-use bevy::math::Vec3;
-use noise::{NoiseFn, Perlin};
-
-use super::{blocks::BlockId, chunk::{Chunk, CHUNK_SIZE}};
+use crate::prelude::*;
 
 pub struct Generator {
     pub seed: u32,
@@ -37,7 +34,14 @@ impl Generator {
     fn generate_block(&self, position: Vec3) -> BlockId {
         let base_height = -50.0;
 
-        let mut density = self.sample_3d(Vec3 {x: position.x, y: position.y + base_height, z: position.z }, 4);
+        let mut density = self.sample_3d(
+            Vec3 {
+                x: position.x,
+                y: position.y + base_height,
+                z: position.z,
+            },
+            4,
+        );
         density -= position.y as f64 * 0.02;
         if density > 0.7 {
             BlockId::Stone

--- a/src/client/terrain/util/mesher.rs
+++ b/src/client/terrain/util/mesher.rs
@@ -1,11 +1,4 @@
-use super::{
-    blocks::{Block, BlockId},
-    chunk::{Chunk, CHUNK_SIZE},
-};
-use bevy::render::{
-    mesh::{Indices, Mesh, PrimitiveTopology},
-    render_asset::RenderAssetUsages,
-};
+use crate::prelude::*;
 
 pub fn create_cube_mesh_from_data(geometry_data: GeometryData) -> Option<Mesh> {
     let GeometryData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub enum NetworkingMessage {
     PlayerLeave(ClientId),
     PlayerUpdate(PlayerState),
     PlayerSync(HashMap<ClientId, PlayerState>),
+    BlockUpdate { position: Vec3, block: BlockId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,20 @@ pub enum NetworkingMessage {
     PlayerSync(HashMap<ClientId, PlayerState>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BlockId {
+    Air,
+    Grass,
+    Dirt,
+    Stone,
+    Bedrock,
+    RedSand,
+    BrownTerracotta,
+    CyanTerracotta,
+    GrayTerracotta,
+    LightGrayTerracotta,
+    OrangeTerracotta,
+    RedTerracotta,
+    Terracotta,
+    YellowTerracotta,
+}

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -1,6 +1,7 @@
-pub mod prelude;
 pub mod networking;
 pub mod player;
+pub mod prelude;
+pub mod terrain;
 
 use crate::prelude::*;
 
@@ -9,5 +10,6 @@ fn main() {
     app.add_plugins(MinimalPlugins);
     app.add_plugins(player::PlayerPlugin);
     app.add_plugins(networking::NetworkingPlugin);
+    app.add_plugins(terrain::TerrainPlugin);
     app.run();
 }

--- a/src/server/networking/systems.rs
+++ b/src/server/networking/systems.rs
@@ -4,6 +4,7 @@ pub fn receive_message_system(
     mut server: ResMut<RenetServer>,
     mut player_states: ResMut<player_resources::PlayerStates>,
     mut server_events: EventReader<ServerEvent>,
+    mut past_block_updates: ResMut<terrain_resources::PastBlockUpdates>,
 ) {
     for client_id in server.clients_id() {
         let message_bytes = server.receive_message(client_id, DefaultChannel::ReliableUnordered);
@@ -45,6 +46,10 @@ pub fn receive_message_system(
                         "Received block update from client {} {} {:?}",
                         client_id, position, block
                     );
+                    past_block_updates
+                        .updates
+                        .push(terrain_events::BlockUpdateEvent { position, block });
+
                     server.broadcast_message_except(
                         client_id,
                         DefaultChannel::ReliableOrdered,
@@ -67,6 +72,7 @@ pub fn handle_events_system(
     mut server: ResMut<RenetServer>,
     mut server_events: EventReader<ServerEvent>,
     mut player_states: ResMut<player_resources::PlayerStates>,
+    past_block_updates: Res<terrain_resources::PastBlockUpdates>,
 ) {
     for event in server_events.read() {
         match event {
@@ -86,7 +92,15 @@ pub fn handle_events_system(
                     DefaultChannel::ReliableOrdered,
                     message,
                 );
-                // TODO: broadcast past block update events to client
+
+                for update in past_block_updates.updates.iter() {
+                    let message = bincode::serialize(&lib::NetworkingMessage::BlockUpdate {
+                        position: update.position,
+                        block: update.block,
+                    })
+                    .unwrap();
+                    server.send_message(*client_id, DefaultChannel::ReliableOrdered, message);
+                }
             }
             ServerEvent::ClientDisconnected { client_id, reason } => {
                 println!("Client {client_id} disconnected: {reason}");

--- a/src/server/networking/systems.rs
+++ b/src/server/networking/systems.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 pub fn receive_message_system(
     mut server: ResMut<RenetServer>,
     mut player_states: ResMut<player_resources::PlayerStates>,
-    mut server_events: EventReader<ServerEvent>,
     mut past_block_updates: ResMut<terrain_resources::PastBlockUpdates>,
 ) {
     for client_id in server.clients_id() {

--- a/src/server/networking/systems.rs
+++ b/src/server/networking/systems.rs
@@ -41,7 +41,7 @@ pub fn receive_message_system(
 
             match message {
                 lib::NetworkingMessage::BlockUpdate { position, block } => {
-                    println!(
+                    info!(
                         "Received block update from client {} {} {:?}",
                         client_id, position, block
                     );

--- a/src/server/networking/systems.rs
+++ b/src/server/networking/systems.rs
@@ -9,6 +9,7 @@ pub fn receive_message_system(
         let message_bytes = server.receive_message(client_id, DefaultChannel::ReliableUnordered);
 
         if message_bytes.is_none() {
+            warn!("Failed to receive message. (ReliableUnordered)");
             continue;
         }
 

--- a/src/server/networking/systems.rs
+++ b/src/server/networking/systems.rs
@@ -15,7 +15,7 @@ pub fn receive_message_system(
         let some_message = bincode::deserialize(&message_bytes.unwrap());
 
         if some_message.is_err() {
-            println!("Failed to deserialize message.");
+            warn!("Failed to deserialize message.");
             continue;
         }
 

--- a/src/server/prelude.rs
+++ b/src/server/prelude.rs
@@ -1,10 +1,15 @@
 // my crates
 pub use hello_bevy as lib;
+pub use hello_bevy::BlockId;
 
 pub use crate::networking::systems as networking_systems;
 
 pub use crate::player::resources as player_resources;
 pub use crate::player::systems as player_systems;
+
+pub use crate::terrain::events as terrain_events;
+pub use crate::terrain::resources as terrain_resources;
+pub use crate::terrain::systems as terrain_systems;
 
 // std crates
 pub use std::collections::HashMap;

--- a/src/server/terrain/events.rs
+++ b/src/server/terrain/events.rs
@@ -1,0 +1,7 @@
+use crate::prelude::*;
+
+#[derive(Event)]
+pub struct BlockUpdateEvent {
+    pub position: Vec3,
+    pub block: BlockId,
+}

--- a/src/server/terrain/mod.rs
+++ b/src/server/terrain/mod.rs
@@ -9,6 +9,6 @@ pub struct TerrainPlugin;
 impl Plugin for TerrainPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<events::BlockUpdateEvent>();
-        app.insert_resource(resources::BlockUpdateResource::new());
+        app.insert_resource(resources::PastBlockUpdates::new());
     }
 }

--- a/src/server/terrain/mod.rs
+++ b/src/server/terrain/mod.rs
@@ -1,0 +1,14 @@
+pub mod events;
+pub mod resources;
+pub mod systems;
+
+use crate::prelude::*;
+
+pub struct TerrainPlugin;
+
+impl Plugin for TerrainPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<events::BlockUpdateEvent>();
+        app.insert_resource(resources::BlockUpdateResource::new());
+    }
+}

--- a/src/server/terrain/resources.rs
+++ b/src/server/terrain/resources.rs
@@ -2,17 +2,12 @@ use terrain_events::BlockUpdateEvent;
 
 use crate::prelude::*;
 
-pub struct ClientsWithBlockUpdate {
-    pub clients: Vec<ClientId>,
-    pub block_update: BlockUpdateEvent,
-}
-
 #[derive(Resource)]
-pub struct BlockUpdateResource {
-    pub updates: Vec<ClientsWithBlockUpdate>,
+pub struct PastBlockUpdates {
+    pub updates: Vec<BlockUpdateEvent>,
 }
 
-impl BlockUpdateResource {
+impl PastBlockUpdates {
     pub fn new() -> Self {
         Self {
             updates: Vec::new(),

--- a/src/server/terrain/resources.rs
+++ b/src/server/terrain/resources.rs
@@ -1,0 +1,21 @@
+use terrain_events::BlockUpdateEvent;
+
+use crate::prelude::*;
+
+pub struct ClientsWithBlockUpdate {
+    pub clients: Vec<ClientId>,
+    pub block_update: BlockUpdateEvent,
+}
+
+#[derive(Resource)]
+pub struct BlockUpdateResource {
+    pub updates: Vec<ClientsWithBlockUpdate>,
+}
+
+impl BlockUpdateResource {
+    pub fn new() -> Self {
+        Self {
+            updates: Vec::new(),
+        }
+    }
+}

--- a/src/server/terrain/resources.rs
+++ b/src/server/terrain/resources.rs
@@ -7,6 +7,12 @@ pub struct PastBlockUpdates {
     pub updates: Vec<BlockUpdateEvent>,
 }
 
+impl Default for PastBlockUpdates {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PastBlockUpdates {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
Implemented multiplayer terrain diff sync.
World is still generated and handled client-side. The server is only used to synchronise events between clients.

1. PlayerA joins world
2. PlayerB joins world
3. PlayerA updates block
4. PlayerA shares block update with server
5. Server stores block update in a history
6. Server broadcasts block update to all clients except the original (PlayerA client)
7. PlayerB receives block update
8. PlayerC joins server
9. Server sends all past block updates to PlayerC
