### PR TITLE
Fix integer overflow

### DIFF
--- a/src/client/terrain/util/chunk.rs
+++ b/src/client/terrain/util/chunk.rs
@@ -20,12 +20,22 @@ impl Chunk {
     }
 
     pub fn get(&self, x: usize, y: usize, z: usize) -> BlockId {
+        self.get_unpadded(x + 1, y + 1, z + 1)
+    }
+
+
+    pub fn get_unpadded(&self, x: usize, y: usize, z: usize) -> BlockId {
         self.data[Self::index(x, y, z)]
     }
 
     pub fn set(&mut self, x: usize, y: usize, z: usize, value: BlockId) {
+        self.set_unpadded(x + 1, y + 1, z + 1, value);
+    }
+
+    pub fn set_unpadded(&mut self, x: usize, y: usize, z: usize, value: BlockId) {
         self.data[Self::index(x, y, z)] = value;
     }
+
 
     #[rustfmt::skip]
     pub fn index(x: usize, y: usize, z: usize) -> usize {

--- a/src/client/terrain/util/chunk.rs
+++ b/src/client/terrain/util/chunk.rs
@@ -3,8 +3,7 @@ use crate::prelude::*;
 pub const CHUNK_SIZE: usize = 32;
 pub const PADDED_CHUNK_SIZE: usize = CHUNK_SIZE + 2;
 pub const PADDED_CHUNK_USIZE: usize = PADDED_CHUNK_SIZE;
-pub const CHUNK_LENGTH: usize =
-    PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE;
+pub const CHUNK_LENGTH: usize = PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE;
 
 pub struct Chunk {
     pub data: [BlockId; CHUNK_LENGTH],

--- a/src/client/terrain/util/chunk.rs
+++ b/src/client/terrain/util/chunk.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-pub const CHUNK_SIZE: i32 = 32;
-pub const PADDED_CHUNK_SIZE: i32 = CHUNK_SIZE + 2;
+pub const CHUNK_SIZE: usize = 32;
+pub const PADDED_CHUNK_SIZE: usize = CHUNK_SIZE + 2;
 pub const PADDED_CHUNK_USIZE: usize = PADDED_CHUNK_SIZE as usize;
 pub const CHUNK_LENGTH: usize =
     (PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE) as usize;
@@ -20,11 +20,11 @@ impl Chunk {
     }
 
     pub fn get(&self, x: usize, y: usize, z: usize) -> BlockId {
-        self.data[Self::index(x + 1, y + 1, z + 1)]
+        self.data[Self::index(x, y, z)]
     }
 
     pub fn set(&mut self, x: usize, y: usize, z: usize, value: BlockId) {
-        self.data[Self::index(x + 1, y + 1, z + 1)] = value;
+        self.data[Self::index(x, y, z)] = value;
     }
 
     #[rustfmt::skip]

--- a/src/client/terrain/util/chunk.rs
+++ b/src/client/terrain/util/chunk.rs
@@ -34,7 +34,6 @@ impl Chunk {
         self.data[Self::index(x, y, z)] = value;
     }
 
-
     #[rustfmt::skip]
     pub fn index(x: usize, y: usize, z: usize) -> usize {
       if (x >= PADDED_CHUNK_SIZE) || (y >= PADDED_CHUNK_SIZE) || (z >= PADDED_CHUNK_SIZE) {

--- a/src/client/terrain/util/chunk.rs
+++ b/src/client/terrain/util/chunk.rs
@@ -2,9 +2,9 @@ use crate::prelude::*;
 
 pub const CHUNK_SIZE: usize = 32;
 pub const PADDED_CHUNK_SIZE: usize = CHUNK_SIZE + 2;
-pub const PADDED_CHUNK_USIZE: usize = PADDED_CHUNK_SIZE as usize;
+pub const PADDED_CHUNK_USIZE: usize = PADDED_CHUNK_SIZE;
 pub const CHUNK_LENGTH: usize =
-    (PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE) as usize;
+    PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE * PADDED_CHUNK_SIZE;
 
 pub struct Chunk {
     pub data: [BlockId; CHUNK_LENGTH],
@@ -23,7 +23,6 @@ impl Chunk {
         self.get_unpadded(x + 1, y + 1, z + 1)
     }
 
-
     pub fn get_unpadded(&self, x: usize, y: usize, z: usize) -> BlockId {
         self.data[Self::index(x, y, z)]
     }
@@ -39,7 +38,7 @@ impl Chunk {
 
     #[rustfmt::skip]
     pub fn index(x: usize, y: usize, z: usize) -> usize {
-      if (x >= PADDED_CHUNK_SIZE as usize) || (y >= PADDED_CHUNK_SIZE as usize) || (z >= PADDED_CHUNK_SIZE as usize) {
+      if (x >= PADDED_CHUNK_SIZE) || (y >= PADDED_CHUNK_SIZE) || (z >= PADDED_CHUNK_SIZE) {
         panic!("Index out of bounds: ({}, {}, {})", x, y, z);
       }
         x + PADDED_CHUNK_USIZE * (y + PADDED_CHUNK_USIZE * z)

--- a/src/client/terrain/util/generator.rs
+++ b/src/client/terrain/util/generator.rs
@@ -19,9 +19,9 @@ impl Generator {
             return;
         }
 
-        for x in -1..=CHUNK_SIZE {
-            for y in -1..=CHUNK_SIZE {
-                for z in -1..=CHUNK_SIZE {
+        for x in 0..=CHUNK_SIZE + 1 {
+            for y in 0..=CHUNK_SIZE + 1 {
+                for z in 0..=CHUNK_SIZE + 1 {
                     let local_position = Vec3::new(x as f32, y as f32, z as f32);
                     let block_position = chunk_origin + local_position;
                     let block = self.generate_block(block_position);

--- a/src/client/terrain/util/generator.rs
+++ b/src/client/terrain/util/generator.rs
@@ -19,9 +19,9 @@ impl Generator {
             return;
         }
 
-        for x in 0..=CHUNK_SIZE + 1 {
-            for y in 0..=CHUNK_SIZE + 1 {
-                for z in 0..=CHUNK_SIZE + 1 {
+        for x in 0..CHUNK_SIZE + 2 {
+            for y in 0..CHUNK_SIZE + 2 {
+                for z in 0..CHUNK_SIZE + 2 {
                     let local_position = Vec3::new(x as f32, y as f32, z as f32);
                     let block_position = chunk_origin + local_position;
                     let block = self.generate_block(block_position);

--- a/src/client/terrain/util/generator.rs
+++ b/src/client/terrain/util/generator.rs
@@ -25,7 +25,7 @@ impl Generator {
                     let local_position = Vec3::new(x as f32, y as f32, z as f32);
                     let block_position = chunk_origin + local_position;
                     let block = self.generate_block(block_position);
-                    chunk.set(x as usize, y as usize, z as usize, block);
+                    chunk.set_unpadded(x as usize, y as usize, z as usize, block);
                 }
             }
         }

--- a/src/client/terrain/util/generator.rs
+++ b/src/client/terrain/util/generator.rs
@@ -25,7 +25,7 @@ impl Generator {
                     let local_position = Vec3::new(x as f32, y as f32, z as f32);
                     let block_position = chunk_origin + local_position;
                     let block = self.generate_block(block_position);
-                    chunk.set_unpadded(x as usize, y as usize, z as usize, block);
+                    chunk.set_unpadded(x, y, z, block);
                 }
             }
         }

--- a/src/client/terrain/util/mesher.rs
+++ b/src/client/terrain/util/mesher.rs
@@ -86,16 +86,16 @@ pub fn create_chunk_mesh(chunk: &Chunk, texture_manager: &TextureManager) -> Opt
         indices: Vec::new(),
     };
 
-    for x in 0..CHUNK_SIZE {
-        for y in 0..CHUNK_SIZE {
-            for z in 0..CHUNK_SIZE {
+    for x in 1..CHUNK_SIZE - 1 { 
+        for y in 1..CHUNK_SIZE - 1 { 
+            for z in 1..CHUNK_SIZE - 1 { 
                 let block_id = chunk.get(x as usize, y as usize, z as usize);
 
                 if block_id == BlockId::Air {
                     continue;
                 }
 
-                fn update_mask(chunk: &Chunk, mask: &mut u8, value: u8, x: i32, y: i32, z: i32) {
+                fn update_mask(chunk: &Chunk, mask: &mut u8, value: u8, x: usize, y: usize, z: usize) {
                     if chunk.get(x as usize, y as usize, z as usize) == BlockId::Air {
                         *mask |= value;
                     }

--- a/src/client/terrain/util/mesher.rs
+++ b/src/client/terrain/util/mesher.rs
@@ -86,9 +86,9 @@ pub fn create_chunk_mesh(chunk: &Chunk, texture_manager: &TextureManager) -> Opt
         indices: Vec::new(),
     };
 
-    for x in 1..CHUNK_SIZE - 1 {
-        for y in 1..CHUNK_SIZE - 1 {
-            for z in 1..CHUNK_SIZE - 1 {
+    for x in 0..CHUNK_SIZE {
+        for y in 0..CHUNK_SIZE {
+            for z in 0..CHUNK_SIZE {
                 let block_id = chunk.get(x, y, z);
 
                 if block_id == BlockId::Air {

--- a/src/client/terrain/util/mesher.rs
+++ b/src/client/terrain/util/mesher.rs
@@ -86,17 +86,24 @@ pub fn create_chunk_mesh(chunk: &Chunk, texture_manager: &TextureManager) -> Opt
         indices: Vec::new(),
     };
 
-    for x in 1..CHUNK_SIZE - 1 { 
-        for y in 1..CHUNK_SIZE - 1 { 
-            for z in 1..CHUNK_SIZE - 1 { 
-                let block_id = chunk.get(x as usize, y as usize, z as usize);
+    for x in 1..CHUNK_SIZE - 1 {
+        for y in 1..CHUNK_SIZE - 1 {
+            for z in 1..CHUNK_SIZE - 1 {
+                let block_id = chunk.get(x, y, z);
 
                 if block_id == BlockId::Air {
                     continue;
                 }
 
-                fn update_mask(chunk: &Chunk, mask: &mut u8, value: u8, x: usize, y: usize, z: usize) {
-                    if chunk.get(x as usize, y as usize, z as usize) == BlockId::Air {
+                fn update_mask(
+                    chunk: &Chunk,
+                    mask: &mut u8,
+                    value: u8,
+                    x: usize,
+                    y: usize,
+                    z: usize,
+                ) {
+                    if chunk.get(x, y, z) == BlockId::Air {
                         *mask |= value;
                     }
                 }


### PR DESCRIPTION
When running the application in `debug` mode, the terrain generation system would crash because of invalid casting from negative i32 to usize. This issue is not noticable in `release` mode because such checks are not included because of performance reasons.

To fix this problem, more care should be taken for the conversion of block coordinates. Also usize should be used instead of i32 where applicable.

Maybe this change is stupid.

## Manual tests

- [x] Client doesn't immediately crash
- [x] Chunks get created successfully
- [x] Chunk meshing doesn't create artifacts
- [x] Blocks can be placed properly
- [x] Blocks can be destroyed properly
