### PR TITLE
Add renet visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `bevy_flair` stylesheets
 - Add `bevy-inspector-egui`
 - Update state management to use bevy `State` instead of a custom `StateMachine`
+- Add `renet_visualizer` to visualize network traffic on the server
 
 ## 0.1.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4352,6 +4352,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "renet_visualizer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3000d08a1d1682a01bc76a7b8d4d8172f5e7ea3eee18546d7c22c76eb36c609b"
+dependencies = [
+ "bevy_ecs",
+ "egui",
+ "renet",
+]
+
+[[package]]
 name = "renetcode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4415,6 +4426,7 @@ dependencies = [
  "rand",
  "rayon",
  "renet",
+ "renet_visualizer",
  "serde",
  "serde-big-array",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = "0.4.38"
 rayon = "1.10.0"
 bevy_flair = "0.1.0"
 bevy-inspector-egui = "0.28.1"
+renet_visualizer = { version = "1.0.0", features = ["bevy"] }
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ path = "src/server/main.rs"
 [features]
 wireframe = []
 debug_ui = []
+renet_visualizer = []
 

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -4,14 +4,15 @@ pub mod player;
 pub mod prelude;
 pub mod terrain;
 
-use bevy::log::LogPlugin;
+use bevy::DefaultPlugins;
 
 use crate::prelude::*;
 
 fn main() {
     let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.add_plugins(LogPlugin::default());
+    // app.add_plugins(MinimalPlugins);
+    app.add_plugins(DefaultPlugins);
+    // app.add_plugins(LogPlugin::default());
     app.add_plugins(player::PlayerPlugin);
     app.add_plugins(networking::NetworkingPlugin);
     app.add_plugins(terrain::TerrainPlugin);

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -4,15 +4,25 @@ pub mod player;
 pub mod prelude;
 pub mod terrain;
 
+#[cfg(feature = "renet_visualizer")]
 use bevy::DefaultPlugins;
+
+#[cfg(not(feature = "renet_visualizer"))]
+use bevy::log::LogPlugin;
 
 use crate::prelude::*;
 
 fn main() {
     let mut app = App::new();
-    // app.add_plugins(MinimalPlugins);
+    #[cfg(not(feature = "renet_visualizer"))]
+    {
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(LogPlugin::default());
+    }
+
+    #[cfg(feature = "renet_visualizer")]
     app.add_plugins(DefaultPlugins);
-    // app.add_plugins(LogPlugin::default());
+
     app.add_plugins(player::PlayerPlugin);
     app.add_plugins(networking::NetworkingPlugin);
     app.add_plugins(terrain::TerrainPlugin);

--- a/src/server/networking/mod.rs
+++ b/src/server/networking/mod.rs
@@ -2,6 +2,9 @@ use std::time::Duration;
 
 pub mod systems;
 
+use bevy_inspector_egui::bevy_egui::EguiPlugin;
+use renet_visualizer::RenetServerVisualizer;
+
 use crate::prelude::*;
 
 const SERVER_ADDR: &str = "127.0.0.1:5000";
@@ -11,6 +14,13 @@ pub struct NetworkingPlugin;
 impl Plugin for NetworkingPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(RenetServerPlugin);
+
+        {
+            // TODO: feature flag this
+            app.add_plugins(EguiPlugin);
+            app.insert_resource(RenetServerVisualizer::<200>::default());
+            app.add_systems(Update, networking_systems::update_visulizer_system);
+        }
 
         let channel_config_unreliable = ChannelConfig {
             channel_id: 0,

--- a/src/server/networking/mod.rs
+++ b/src/server/networking/mod.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 pub mod systems;
 
+#[cfg(feature = "renet_visualizer")]
 use bevy_inspector_egui::bevy_egui::EguiPlugin;
+#[cfg(feature = "renet_visualizer")]
 use renet_visualizer::RenetServerVisualizer;
 
 use crate::prelude::*;
@@ -15,8 +17,8 @@ impl Plugin for NetworkingPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(RenetServerPlugin);
 
+        #[cfg(feature = "renet_visualizer")]
         {
-            // TODO: feature flag this
             app.add_plugins(EguiPlugin);
             app.insert_resource(RenetServerVisualizer::<200>::default());
             app.add_systems(

--- a/src/server/networking/mod.rs
+++ b/src/server/networking/mod.rs
@@ -19,7 +19,13 @@ impl Plugin for NetworkingPlugin {
             // TODO: feature flag this
             app.add_plugins(EguiPlugin);
             app.insert_resource(RenetServerVisualizer::<200>::default());
-            app.add_systems(Update, networking_systems::update_visulizer_system);
+            app.add_systems(
+                Update,
+                (
+                    networking_systems::update_visulizer_system,
+                    networking_systems::handle_events_for_visualizer_system,
+                ),
+            );
         }
 
         let channel_config_unreliable = ChannelConfig {

--- a/src/server/networking/systems.rs
+++ b/src/server/networking/systems.rs
@@ -1,5 +1,6 @@
-// TODO: feature flag these imports
+#[cfg(feature = "renet_visualizer")]
 use bevy_inspector_egui::bevy_egui::EguiContexts;
+#[cfg(feature = "renet_visualizer")]
 use renet_visualizer::RenetServerVisualizer;
 
 use crate::prelude::*;
@@ -166,7 +167,7 @@ pub fn handle_events_system(
     }
 }
 
-// TODO: feature flag this
+#[cfg(feature = "renet_visualizer")]
 pub fn handle_events_for_visualizer_system(
     mut server_events: EventReader<ServerEvent>,
     mut visualizer: ResMut<RenetServerVisualizer<200>>,
@@ -183,7 +184,7 @@ pub fn handle_events_for_visualizer_system(
     }
 }
 
-// TODO: Feature flag this
+#[cfg(feature = "renet_visualizer")]
 pub fn update_visulizer_system(
     mut egui_contexts: EguiContexts,
     mut visualizer: ResMut<RenetServerVisualizer<200>>,


### PR DESCRIPTION
Add [renet_visualizer](https://crates.io/crates/renet_visualizer) crate to visualize client traffic on the server side.
This requires adding a GUI to the server and default plugins -> Feature flag.

This should aid in debugging large traffic such as massive world batch requests and stuff.
This could prove to be useful for: #33 

https://github.com/user-attachments/assets/cd0a28a7-7f55-4be0-bb50-5c650d7814e0

Heavily inspired by the visualizer example:
https://github.com/lucaspoffo/renet/blob/master/demo_bevy/src/bin/server.rs

## Todo
 - [x]  Feature flag
 - [x] CHANGELOG

## Problems
- [ ] Panics when new clients connect when GUI is open (bug report?)