### PR TITLE
Ambient occlusion

### DIFF
--- a/src/client/terrain/systems.rs
+++ b/src/client/terrain/systems.rs
@@ -86,11 +86,6 @@ pub fn handle_chunk_mesh_update_events_system(
         let chunk_option = chunk_manager.get_chunk(event.position);
         match chunk_option {
             Some(chunk) => {
-                for (entity, chunk_mesh) in mesh_query.iter_mut() {
-                    if Chunk::key_eq_pos(chunk_mesh.key, chunk.position) {
-                        commands.entity(entity).despawn();
-                    }
-                }
                 add_chunk_objects(
                     &mut commands,
                     &mut meshes,
@@ -105,6 +100,11 @@ pub fn handle_chunk_mesh_update_events_system(
                     &texture_manager,
                     &mut meshes,
                 );
+                for (entity, chunk_mesh) in mesh_query.iter_mut() {
+                    if Chunk::key_eq_pos(chunk_mesh.key, chunk.position) {
+                        commands.entity(entity).despawn();
+                    }
+                }
             }
             None => {
                 println!("No chunk found");

--- a/src/client/terrain/util/blocks.rs
+++ b/src/client/terrain/util/blocks.rs
@@ -32,6 +32,7 @@ pub mod client_block {
     use MeshRepresentation::*;
 
     pub struct BlockProperties {
+        pub transparent: bool,
         pub has_collider: bool,
         pub mesh_representation: MeshRepresentation,
     }
@@ -40,30 +41,33 @@ pub mod client_block {
         use TextureName::*;
 
         let touple = match block_id {
-            BlockId::Air => (false, None),
+            BlockId::Air => (true, false, None),
             BlockId::Grass => (
+                false,
                 true,
                 Cube([GrassTop, Dirt, GrassSide, GrassSide, GrassSide, GrassSide]),
             ),
-            BlockId::Dirt => (true, Cube([Dirt; 6])),
-            BlockId::Stone => (true, Cube([Stone; 6])),
-            BlockId::CobbleStone => (true, Cube([CobbleStone; 6])),
-            BlockId::Bedrock => (true, Cube([Bedrock; 6])),
-            BlockId::IronOre => (true, Cube([IronOre; 6])),
-            BlockId::CoalOre => (true, Cube([CoalOre; 6])),
-            BlockId::OakLeaves => (true, Cube([OakLeaves; 6])),
+            BlockId::Dirt => (false, true, Cube([Dirt; 6])),
+            BlockId::Stone => (false, true, Cube([Stone; 6])),
+            BlockId::CobbleStone => (false, true, Cube([CobbleStone; 6])),
+            BlockId::Bedrock => (false, true, Cube([Bedrock; 6])),
+            BlockId::IronOre => (false, true, Cube([IronOre; 6])),
+            BlockId::CoalOre => (false, true, Cube([CoalOre; 6])),
+            BlockId::OakLeaves => (false, true, Cube([OakLeaves; 6])),
             BlockId::OakLog => (
+                false,
                 true,
                 Cube([
                     OakLogTop, OakLogTop, OakLogSide, OakLogSide, OakLogSide, OakLogSide,
                 ]),
             ),
-            BlockId::Tallgrass => (false, Cross([Tallgrass, Tallgrass])),
+            BlockId::Tallgrass => (true, false, Cross([Tallgrass, Tallgrass])),
         };
 
         BlockProperties {
-            has_collider: touple.0,
-            mesh_representation: touple.1,
+            transparent: touple.0,
+            has_collider: touple.1,
+            mesh_representation: touple.2,
         }
     }
 

--- a/src/client/terrain/util/cross_mesher.rs
+++ b/src/client/terrain/util/cross_mesher.rs
@@ -21,6 +21,7 @@ fn create_cross_geometry_for_chunk(
     let mut position = vec![];
     let mut uv = vec![];
     let mut normal = vec![];
+    let mut color = vec![];
     let mut indices = vec![];
 
     let mut index_offset = 0;
@@ -52,6 +53,7 @@ fn create_cross_geometry_for_chunk(
                                 face_uv[1] + vertex.uv[1] * 0.25,
                             ]);
                             normal.push(vertex.normal);
+                            color.push([1.0, 1.0, 1.0, 1.0]);
                         }
 
                         let offsets = [0, 1, 3, 1, 2, 3];
@@ -70,6 +72,7 @@ fn create_cross_geometry_for_chunk(
         position,
         uv,
         normal,
+        color,
         indices,
     }
 }

--- a/src/client/terrain/util/cube_mesher.rs
+++ b/src/client/terrain/util/cube_mesher.rs
@@ -16,6 +16,7 @@ pub fn create_cube_geometry_data(
     let mut position = Vec::new();
     let mut uv = Vec::new();
     let mut normal = Vec::new();
+    let mut color = Vec::new();
     let mut indices = Vec::new();
     let mut index_offset = 0;
 
@@ -38,6 +39,8 @@ pub fn create_cube_geometry_data(
                 block_uvs[1] + (1.0 - vertex.uv[1]) * 0.25,
             ]);
             normal.push(vertex.normal);
+
+            color.push([rand::random(), rand::random(), rand::random(), 1.0]);
         }
 
         let offsets = [0, 1, 2, 2, 1, 3];
@@ -51,6 +54,7 @@ pub fn create_cube_geometry_data(
         position,
         uv,
         normal,
+        color,
         indices,
     }
 }
@@ -60,6 +64,7 @@ pub fn create_chunk_mesh(chunk: &Chunk, texture_manager: &TextureManager) -> Opt
         position: Vec::new(),
         uv: Vec::new(),
         normal: Vec::new(),
+        color: Vec::new(),
         indices: Vec::new(),
     };
 
@@ -116,6 +121,7 @@ pub fn create_chunk_mesh(chunk: &Chunk, texture_manager: &TextureManager) -> Opt
                 geometry_data.position.extend(cube_data.position);
                 geometry_data.uv.extend(cube_data.uv);
                 geometry_data.normal.extend(cube_data.normal);
+                geometry_data.color.extend(cube_data.color);
             }
         }
     }
@@ -200,6 +206,12 @@ mod tests {
             ],
             uv: vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
             normal: vec![[0.0, 0.0, 1.0]; 4],
+            color: vec![
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ],
             indices: vec![0, 1, 2, 2, 3, 0],
         };
 
@@ -216,6 +228,7 @@ mod tests {
         assert_eq!(geometry_data.position.len(), 6 * 4);
         assert_eq!(geometry_data.uv.len(), 6 * 4);
         assert_eq!(geometry_data.normal.len(), 6 * 4);
+        assert_eq!(geometry_data.color.len(), 6 * 4);
         assert_eq!(geometry_data.indices.len(), 6 * 6);
     }
 }

--- a/src/client/terrain/util/cube_mesher.rs
+++ b/src/client/terrain/util/cube_mesher.rs
@@ -46,19 +46,15 @@ pub fn create_cube_geometry_data(
                 let dy = dy as f32 + 0.5;
                 let dz = dz as f32 + 0.5;
 
-                if !Chunk::valid_padded(
-                    (vertex.position[0] * 0.5 + x + dx) as usize,
-                    (vertex.position[1] * 0.5 + y + dy) as usize,
-                    (vertex.position[2] * 0.5 + z + dz) as usize,
-                ) {
+                let cx = (vertex.position[0] * 0.5 + x + dx) as usize;
+                let cy = (vertex.position[1] * 0.5 + y + dy) as usize;
+                let cz = (vertex.position[2] * 0.5 + z + dz) as usize;
+
+                if !Chunk::valid_padded(cx, cy, cz) {
                     return false;
                 }
 
-                let neighbor_id = chunk.get_unpadded(
-                    (vertex.position[0] * 0.5 + x + dx) as usize,
-                    (vertex.position[1] * 0.5 + y + dy) as usize,
-                    (vertex.position[2] * 0.5 + z + dz) as usize,
-                );
+                let neighbor_id = chunk.get_unpadded(cx, cy, cz);
                 !block_properties(neighbor_id).transparent
             };
 
@@ -75,7 +71,8 @@ pub fn create_cube_geometry_data(
             let ao_count: f32 = checks.iter().map(|v| *v as u8 as f32).sum();
             let max_ao: f32 = 8.0;
 
-            let ao_value = (max_ao - ao_count) / max_ao;
+            let mut ao_value = (max_ao - ao_count) / max_ao;
+            ao_value += 0.5;
 
             color.push([ao_value, ao_value, ao_value, 1.0]);
         }
@@ -261,8 +258,15 @@ mod tests {
     fn test_create_cube_geometry_data() {
         let texture_manager = TextureManager::new();
         let chunk = Chunk::new(Vec3::ZERO);
-        let geometry_data =
-            create_cube_geometry_data(0.0, 0.0, 0.0, 0b111111, BlockId::Stone, &texture_manager, &chunk);
+        let geometry_data = create_cube_geometry_data(
+            0.0,
+            0.0,
+            0.0,
+            0b111111,
+            BlockId::Stone,
+            &texture_manager,
+            &chunk,
+        );
 
         assert_eq!(geometry_data.position.len(), 6 * 4);
         assert_eq!(geometry_data.uv.len(), 6 * 4);

--- a/src/client/terrain/util/cube_mesher.rs
+++ b/src/client/terrain/util/cube_mesher.rs
@@ -40,7 +40,7 @@ pub fn create_cube_geometry_data(
             ]);
             normal.push(vertex.normal);
 
-            color.push([rand::random(), rand::random(), rand::random(), 1.0]);
+            color.push([1.0, 1.0, 1.0, 1.0]);
         }
 
         let offsets = [0, 1, 2, 2, 1, 3];

--- a/src/client/terrain/util/mesher.rs
+++ b/src/client/terrain/util/mesher.rs
@@ -1,3 +1,5 @@
+use bevy::reflect::List;
+
 use crate::prelude::*;
 
 pub fn create_cube_mesh_from_data(geometry_data: GeometryData) -> Option<Mesh> {
@@ -5,11 +7,16 @@ pub fn create_cube_mesh_from_data(geometry_data: GeometryData) -> Option<Mesh> {
         position,
         uv,
         normal,
+        color,
         indices,
     } = geometry_data;
 
-    if (position.is_empty() || uv.is_empty() || normal.is_empty() || indices.is_empty())
-        || (position.len() != uv.len() || uv.len() != normal.len())
+    if (position.is_empty()
+        || uv.is_empty()
+        || normal.is_empty()
+        || indices.is_empty()
+        || color.is_empty())
+        || (position.len() != uv.len() || uv.len() != normal.len() || normal.len() != color.len())
     {
         return None;
     }
@@ -22,6 +29,7 @@ pub fn create_cube_mesh_from_data(geometry_data: GeometryData) -> Option<Mesh> {
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, position)
         .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uv)
         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normal)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_COLOR, color)
         .with_inserted_indices(Indices::U32(indices)),
     )
 }
@@ -37,4 +45,5 @@ pub struct GeometryData {
     pub uv: Vec<[f32; 2]>,
     pub normal: Vec<[f32; 3]>,
     pub indices: Vec<u32>,
+    pub color: Vec<[f32; 4]>,
 }

--- a/src/client/terrain/util/mesher.rs
+++ b/src/client/terrain/util/mesher.rs
@@ -1,5 +1,3 @@
-use bevy::reflect::List;
-
 use crate::prelude::*;
 
 pub fn create_cube_mesh_from_data(geometry_data: GeometryData) -> Option<Mesh> {


### PR DESCRIPTION
## Ambient Occlusion

> In graphics, ambient occlusion is a shadowing technique used to make 3D objects look more realistic by simulating the soft shadows that should naturally occur when indirect or ambient lighting is cast out onto your scene.
> https://www.pluralsight.com/resources/blog/software-development/understanding-ambient-occlusion

Implemented vertex level ambient occlusion for blocks with cube mesh representation.
There is a neighbor check performed on each vertex, thus making the mesher now super duper slow.
The more neighbors a given vertex has, the darker its color becomes.

The vertex color data could be influenced by light sources in the future and lighting could be calculated using floodfill.

<details><summary>Without</summary>
<p>

![Screenshot From 2025-03-09 13-19-18](https://github.com/user-attachments/assets/077e161e-1ba7-4130-823b-2e17f8aa1ba3)

</p>
</details> 

<details><summary>With</summary>
<p>


![Screenshot From 2025-03-09 13-19-42](https://github.com/user-attachments/assets/fabfe020-4a96-4ba5-b92d-4bbf94cc1f36)

</p>
</details> 

## Problems
* AO is not calculated correctly at chunk borders :/
* Performance is dog water


## Additional sources

https://0fps.net/2013/07/03/ambient-occlusion-for-minecraft-like-worlds/

> may have been borrowed from https://github.com/CuddlyBunion341/tsmc2/blob/c1e94bc8dad44154835ab858dd783de1185af037/src/game/world/ChunkMesher.ts#L173-L199